### PR TITLE
[fix] Fix bad detection of branch develop in github workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Force push develop to main
         run: |
-          if [ `git branch --show-current` = "develop" ] ; then
+          if [ "$(git branch --show-current)" = "develop" ] ; then
             git reset --hard && \
               git push --force origin develop:main && \
               git fetch && \
@@ -33,6 +33,6 @@ jobs:
 
       - name: Reload mock backend on staging
         run: |
-          if [ `git branch --show-current` = "develop" ] ; then
+          if [ "$(git branch --show-current)" = "develop" ] ; then
             bundle exec ruby bin/reload_mock_backend.rb
           fi


### PR DESCRIPTION
There is some errors in the workflow in steps:
* Force push develop to main
* Reload mock backend on staging

The error was:
```sh
/home/runner/work/_temp/12b34124-4d4e-458f-bc44-0aacecec4449.sh: line 1: [: =: unary operator expected
````

Note that this fix is not tested, just a shell sanitation