### PR TITLE
[data] Add payloads data for students status

### DIFF
--- a/payloads/api_particulier_v2_mesri_student_status/README.md
+++ b/payloads/api_particulier_v2_mesri_student_status/README.md
@@ -224,7 +224,7 @@
       {
         "dateDebutInscription": "2023-07-01",
         "dateFinInscription": "2024-08-31",
-        "statut": "ADMIS",
+        "statut": "admis",
         "codeCommune": "75009",
         "etablissement": {
           "uai": "0331023W",

--- a/payloads/api_particulier_v2_mesri_student_status/ine_1234567890B_expired.yaml
+++ b/payloads/api_particulier_v2_mesri_student_status/ine_1234567890B_expired.yaml
@@ -1,0 +1,25 @@
+---
+description: 'Étudiant 1234567890B inscrit (appel par INE), année scolaire 2022 à Toulouse'
+params:
+  ine: '1234567890B'
+status: 200
+payload: |-
+  {
+    "ine": "1234567890B",
+    "nom": "Longchambon",
+    "prenom": "Thomas",
+    "dateNaissance": "2001-01-01",
+    "inscriptions": [
+      {
+        "dateDebutInscription": "2022-09-01",
+        "dateFinInscription": "2023-08-31",
+        "statut": "inscrit",
+        "codeCommune": "31555",
+        "etablissement": {
+          "uai": "0313124C",
+          "nomEtablissement": "Université Toulouse Capitole"
+        },
+        "regime": "formation initiale"
+      }
+    ]
+  }

--- a/payloads/api_particulier_v2_mesri_student_status/ine_1234567890C_2023_toulouse.yaml
+++ b/payloads/api_particulier_v2_mesri_student_status/ine_1234567890C_2023_toulouse.yaml
@@ -1,0 +1,25 @@
+---
+description: 'Étudiant 1234567890C inscrit (appel par INE), année scolaire 2023 à Toulouse'
+params:
+  ine: '1234567890C'
+status: 200
+payload: |-
+  {
+    "ine": "1234567890C",
+    "nom": "Charbonneau",
+    "prenom": "Axelle",
+    "dateNaissance": "2001-01-02",
+    "inscriptions": [
+      {
+        "dateDebutInscription": "2023-09-01",
+        "dateFinInscription": "2024-08-31",
+        "statut": "inscrit",
+        "codeCommune": "31555",
+        "etablissement": {
+          "uai": "0313124C",
+          "nomEtablissement": "Université Toulouse Capitole"
+        },
+        "regime": "formation initiale"
+      }
+    ]
+  }

--- a/payloads/api_particulier_v2_mesri_student_status/ine_1234567890D_2023_toulouse.yaml
+++ b/payloads/api_particulier_v2_mesri_student_status/ine_1234567890D_2023_toulouse.yaml
@@ -1,0 +1,25 @@
+---
+description: 'Étudiant 1234567890D inscrit (appel par INE), année scolaire 2023 à Toulouse'
+params:
+  ine: '1234567890D'
+status: 200
+payload: |-
+  {
+    "ine": "1234567890D",
+    "nom": "Montgomery",
+    "prenom": "Marie",
+    "dateNaissance": "2001-01-03",
+    "inscriptions": [
+      {
+        "dateDebutInscription": "2023-09-01",
+        "dateFinInscription": "2024-08-31",
+        "statut": "inscrit",
+        "codeCommune": "31555",
+        "etablissement": {
+          "uai": "0313124C",
+          "nomEtablissement": "Université Toulouse Capitole"
+        },
+        "regime": "formation initiale"
+      }
+    ]
+  }

--- a/payloads/api_particulier_v2_mesri_student_status/ine_1234567890E_2023_paris.yaml
+++ b/payloads/api_particulier_v2_mesri_student_status/ine_1234567890E_2023_paris.yaml
@@ -1,0 +1,25 @@
+---
+description: 'Étudiant 1234567890E inscrit (appel par INE), année scolaire 2023 à Paris'
+params:
+  ine: '1234567890E'
+status: 200
+payload: |-
+  {
+    "ine": "1234567890E",
+    "nom": "Granet",
+    "prenom": "Cyril",
+    "dateNaissance": "2001-01-04",
+    "inscriptions": [
+      {
+        "dateDebutInscription": "2023-09-01",
+        "dateFinInscription": "2024-08-31",
+        "statut": "inscrit",
+        "codeCommune": "75020",
+        "etablissement": {
+          "uai": "0750106H",
+          "nomEtablissement": "ECOLE TECHNOLOGIQUE PRIVEE"
+        },
+        "regime": "formation initiale"
+      }
+    ]
+  }

--- a/payloads/api_particulier_v2_mesri_student_status/ine_1234567890F_2024_toulouse.yaml
+++ b/payloads/api_particulier_v2_mesri_student_status/ine_1234567890F_2024_toulouse.yaml
@@ -1,0 +1,25 @@
+---
+description: 'Étudiant 1234567890F inscrit (appel par INE), année scolaire 2024 à Toulouse'
+params:
+  ine: '1234567890F'
+status: 200
+payload: |-
+  {
+    "ine": "1234567890F",
+    "nom": "Le Tonnelier",
+    "prenom": "Pierre-Marie",
+    "dateNaissance": "2001-01-03",
+    "inscriptions": [
+      {
+        "dateDebutInscription": "2024-09-01",
+        "dateFinInscription": "2025-08-31",
+        "statut": "inscrit",
+        "codeCommune": "31555",
+        "etablissement": {
+          "uai": "0313124C",
+          "nomEtablissement": "Université Toulouse Capitole"
+        },
+        "regime": "formation initiale"
+      }
+    ]
+  }

--- a/payloads/api_particulier_v2_mesri_student_status/summary.csv
+++ b/payloads/api_particulier_v2_mesri_student_status/summary.csv
@@ -42,7 +42,7 @@ Titre,Description,Paramètres,Status,Réponse
     {
       ""dateDebutInscription"": ""2023-07-01"",
       ""dateFinInscription"": ""2024-08-31"",
-      ""statut"": ""ADMIS"",
+      ""statut"": ""admis"",
       ""codeCommune"": ""75009"",
       ""etablissement"": {
         ""uai"": ""0331023W"",


### PR DESCRIPTION
Add 5 cases:
* Étudiant 1234567890B inscrit (appel par INE), année scolaire 2022 à Toulouse
* Étudiant 1234567890C inscrit (appel par INE), année scolaire 2023 à Toulouse
* Étudiant 1234567890D inscrit (appel par INE), année scolaire 2023 à Toulouse
* Étudiant 1234567890E inscrit (appel par INE), année scolaire 2023 à Paris
* Étudiant 1234567890F inscrit (appel par INE), année scolaire 2024 à Toulouse

The first four cases matches payloads from PR #70 