### PR TITLE
CNAV -- Recipient is required for FC and not for identity

### DIFF
--- a/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/200_beneficiaire.yaml
+++ b/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/200_beneficiaire.yaml
@@ -13,7 +13,6 @@ params:
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'M'
-  recipient: '13002526500013'
 status: 200
 payload: |-
   {

--- a/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/200_non_beneficiaire.yaml
+++ b/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/200_non_beneficiaire.yaml
@@ -12,7 +12,6 @@ params:
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'M'
-  recipient: '13002526500013'
 status: 200
 payload: |-
   {

--- a/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/404.yaml
+++ b/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/404.yaml
@@ -2,7 +2,6 @@
 description: |-
   ## Allocataire non trouvé
 params:
-  recipient: '13002526500013'
   nomNaissance: 'DUBOCHE'
   prenoms[]:
   - 'JEROME'

--- a/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/503.yaml
+++ b/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/503.yaml
@@ -1,7 +1,6 @@
 ---
 description: "Timeout - délai d'attente dépassé"
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00503'
   codePaysLieuDeNaissance: '99100'
   sexe: F

--- a/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/README.md
+++ b/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/README.md
@@ -21,8 +21,7 @@
     "jourDateDeNaissance": 1,
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
-    "sexe": "M",
-    "recipient": "13002526500013"
+    "sexe": "M"
   }
   ```
 
@@ -47,7 +46,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'nomUsage=DUPONT' -d 'nomNaissance=MARTIN' -d 'prenoms[][]=PIERRE' -d 'prenoms[][]=RICHARD' -d 'anneeDateDeNaissance=1987' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=1' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' -d 'recipient=13002526500013' \
+    -G -d 'nomUsage=DUPONT' -d 'nomNaissance=MARTIN' -d 'prenoms[][]=PIERRE' -d 'prenoms[][]=RICHARD' -d 'anneeDateDeNaissance=1987' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=1' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/allocation-adulte-handicape"
   ```
 
@@ -74,8 +73,7 @@
     "jourDateDeNaissance": 1,
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
-    "sexe": "M",
-    "recipient": "13002526500013"
+    "sexe": "M"
   }
   ```
 
@@ -100,7 +98,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'nomUsage=CHIRAC' -d 'nomNaissance=MARTIN' -d 'prenoms[][]=JACQUES' -d 'anneeDateDeNaissance=1987' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=1' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' -d 'recipient=13002526500013' \
+    -G -d 'nomUsage=CHIRAC' -d 'nomNaissance=MARTIN' -d 'prenoms[][]=JACQUES' -d 'anneeDateDeNaissance=1987' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=1' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/allocation-adulte-handicape"
   ```
 
@@ -117,7 +115,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "nomNaissance": "DUBOCHE",
     "prenoms[]": [
       "JEROME"
@@ -153,7 +150,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
+    -G -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/allocation-adulte-handicape"
   ```
 
@@ -170,7 +167,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00503",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -199,7 +195,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/allocation-adulte-handicape"
   ```
 

--- a/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/summary.csv
+++ b/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/summary.csv
@@ -1,18 +1,18 @@
 Titre,Description,Paramètres,Status,Réponse
-,## Bénéficiaire,"{""nomUsage"":""DUPONT"",""nomNaissance"":""MARTIN"",""prenoms[]"":[""PIERRE"",""RICHARD""],""anneeDateDeNaissance"":1987,""moisDateDeNaissance"":12,""jourDateDeNaissance"":1,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M"",""recipient"":""13002526500013""}",200,"{
+,## Bénéficiaire,"{""nomUsage"":""DUPONT"",""nomNaissance"":""MARTIN"",""prenoms[]"":[""PIERRE"",""RICHARD""],""anneeDateDeNaissance"":1987,""moisDateDeNaissance"":12,""jourDateDeNaissance"":1,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",200,"{
   ""status"": ""beneficiaire"",
   ""dateDebut"": ""2022-11-29""
 }"
-,## Non bénéficiaire,"{""nomUsage"":""CHIRAC"",""nomNaissance"":""MARTIN"",""prenoms[]"":[""JACQUES""],""anneeDateDeNaissance"":1987,""moisDateDeNaissance"":12,""jourDateDeNaissance"":1,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M"",""recipient"":""13002526500013""}",200,"{
+,## Non bénéficiaire,"{""nomUsage"":""CHIRAC"",""nomNaissance"":""MARTIN"",""prenoms[]"":[""JACQUES""],""anneeDateDeNaissance"":1987,""moisDateDeNaissance"":12,""jourDateDeNaissance"":1,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",200,"{
   ""status"": ""non_beneficiaire"",
   ""dateDebut"": null
 }"
-,## Allocataire non trouvé,"{""recipient"":""13002526500013"",""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
+,## Allocataire non trouvé,"{""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
 }"
-,Timeout - délai d'attente dépassé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
+,Timeout - délai d'attente dépassé,"{""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
   ""error"": ""network_error"",
   ""reason"": ""timeout of 10000 ms exceeded"",
   ""message"": ""Une erreur est survenue lors de l'appel au fournisseur de donnée""

--- a/payloads/api_particulier_v2_cnav_allocation_soutien_familial/404.yaml
+++ b/payloads/api_particulier_v2_cnav_allocation_soutien_familial/404.yaml
@@ -2,7 +2,6 @@
 description: |-
   ## Allocataire non trouvé
 params:
-  recipient: '13002526500013'
   nomNaissance: 'DUBOCHE'
   prenoms[]:
   - 'JEROME'

--- a/payloads/api_particulier_v2_cnav_allocation_soutien_familial/503.yaml
+++ b/payloads/api_particulier_v2_cnav_allocation_soutien_familial/503.yaml
@@ -1,7 +1,6 @@
 ---
 description: "Timeout - délai d'attente dépassé"
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00503'
   codePaysLieuDeNaissance: '99100'
   sexe: F

--- a/payloads/api_particulier_v2_cnav_allocation_soutien_familial/README.md
+++ b/payloads/api_particulier_v2_cnav_allocation_soutien_familial/README.md
@@ -116,7 +116,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "nomNaissance": "DUBOCHE",
     "prenoms[]": [
       "JEROME"
@@ -152,7 +151,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
+    -G -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/allocation-soutien-familial"
   ```
 
@@ -169,7 +168,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00503",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -198,7 +196,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/allocation-soutien-familial"
   ```
 

--- a/payloads/api_particulier_v2_cnav_allocation_soutien_familial/summary.csv
+++ b/payloads/api_particulier_v2_cnav_allocation_soutien_familial/summary.csv
@@ -9,12 +9,12 @@ Titre,Description,Paramètres,Status,Réponse
   ""dateDebut"": null,
   ""dateFin"": null
 }"
-,## Allocataire non trouvé,"{""recipient"":""13002526500013"",""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
+,## Allocataire non trouvé,"{""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
 }"
-,Timeout - délai d'attente dépassé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
+,Timeout - délai d'attente dépassé,"{""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
   ""error"": ""network_error"",
   ""reason"": ""timeout of 10000 ms exceeded"",
   ""message"": ""Une erreur est survenue lors de l'appel au fournisseur de donnée""

--- a/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/200-beneficiaire_avec_participation-feminin.yaml
+++ b/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/200-beneficiaire_avec_participation-feminin.yaml
@@ -8,7 +8,6 @@ description: |-
   - [Param. appel] Deux prénoms
   - [Réponse] statut bénéficiaire de la complémentaire santé solidaire AVEC participation financière
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100' #Bénéficiaire né en France
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/200-beneficiaire_sans_participation-masculin-pays_etranger.yaml
+++ b/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/200-beneficiaire_sans_participation-masculin-pays_etranger.yaml
@@ -8,7 +8,6 @@ description: |-
   - [Param. appel] Deux prénoms
   - [Réponse] statut bénéficiaire de la complémentaire santé solidaire SANS participation financière
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08481'
   codePaysLieuDeNaissance: '99127'
   sexe: 'M'

--- a/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/200-non-beneficiaire_masculin.yaml
+++ b/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/200-non-beneficiaire_masculin.yaml
@@ -7,7 +7,6 @@ description: |-
   - [Param. appel] sexe masculin
   - [Réponse] statut non-bénéficiaire de la complémentaire santé solidaire
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100' #Code 99100 pour la France
   sexe: 'M'

--- a/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/404.yaml
+++ b/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/404.yaml
@@ -1,7 +1,6 @@
 ---
 description: 'Dossier non trouvé'
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00404'
   codePaysLieuDeNaissance: '99100'
   sexe: F

--- a/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/503.yaml
+++ b/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/503.yaml
@@ -1,7 +1,6 @@
 ---
 description: "Timeout - délai d'attente dépassé"
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00503'
   codePaysLieuDeNaissance: '99100'
   sexe: F

--- a/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/README.md
+++ b/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/README.md
@@ -16,7 +16,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -52,7 +51,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=DUPONT' -d 'prenoms[]=JEANNE' -d 'prenoms[]=LAURE' -d 'anneeDateDeNaissance=1993' -d 'moisDateDeNaissance=8' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=DUPONT' -d 'prenoms[]=JEANNE' -d 'prenoms[]=LAURE' -d 'anneeDateDeNaissance=1993' -d 'moisDateDeNaissance=8' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/complementaire-sante-solidaire"
   ```
 
@@ -75,7 +74,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08481",
     "codePaysLieuDeNaissance": "99127",
     "sexe": "M",
@@ -111,7 +109,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08481' -d 'codePaysLieuDeNaissance=99127' -d 'sexe=M' -d 'nomUsage=DUPONT' -d 'prenoms[]=PIERRE' -d 'prenoms[]=PAUL' -d 'anneeDateDeNaissance=1984' -d 'moisDateDeNaissance=12' \
+    -G -d 'codeInseeLieuDeNaissance=08481' -d 'codePaysLieuDeNaissance=99127' -d 'sexe=M' -d 'nomUsage=DUPONT' -d 'prenoms[]=PIERRE' -d 'prenoms[]=PAUL' -d 'anneeDateDeNaissance=1984' -d 'moisDateDeNaissance=12' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/complementaire-sante-solidaire"
   ```
 
@@ -133,7 +131,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "M",
@@ -168,7 +165,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' -d 'nomUsage=DUPONT' -d 'prenoms[]=PIERRE' -d 'anneeDateDeNaissance=1966' -d 'moisDateDeNaissance=6' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' -d 'nomUsage=DUPONT' -d 'prenoms[]=PIERRE' -d 'anneeDateDeNaissance=1966' -d 'moisDateDeNaissance=6' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/complementaire-sante-solidaire"
   ```
 
@@ -185,7 +182,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00404",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -214,7 +210,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00404' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00404' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/complementaire-sante-solidaire"
   ```
 
@@ -231,7 +227,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00503",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -260,7 +255,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/complementaire-sante-solidaire"
   ```
 

--- a/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/summary.csv
+++ b/payloads/api_particulier_v2_cnav_complementaire_sante_solidaire/summary.csv
@@ -5,7 +5,7 @@ Ce cas permet de tester :
 - [Param. appel] lieu de naissance en France
 - [Param. appel] sexe féminin
 - [Param. appel] Deux prénoms
-- [Réponse] statut bénéficiaire de la complémentaire santé solidaire AVEC participation financière","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""DUPONT"",""prenoms"":[""JEANNE"",""LAURE""],""anneeDateDeNaissance"":1993,""moisDateDeNaissance"":8}",200,"{
+- [Réponse] statut bénéficiaire de la complémentaire santé solidaire AVEC participation financière","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""DUPONT"",""prenoms"":[""JEANNE"",""LAURE""],""anneeDateDeNaissance"":1993,""moisDateDeNaissance"":8}",200,"{
   ""status"": ""beneficiaire_avec_participation_financiere"",
   ""dateDebut"": ""2023-06-01"",
   ""dateFin"": ""2024-06-01""
@@ -16,7 +16,7 @@ Ce cas permet de tester :
 - [Param. appel] Pays de naissance autre que la France
 - [Param. appel] sexe masculin
 - [Param. appel] Deux prénoms
-- [Réponse] statut bénéficiaire de la complémentaire santé solidaire SANS participation financière","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08481"",""codePaysLieuDeNaissance"":""99127"",""sexe"":""M"",""nomUsage"":""DUPONT"",""prenoms"":[""PIERRE"",""PAUL""],""anneeDateDeNaissance"":1984,""moisDateDeNaissance"":12}",200,"{
+- [Réponse] statut bénéficiaire de la complémentaire santé solidaire SANS participation financière","{""codeInseeLieuDeNaissance"":""08481"",""codePaysLieuDeNaissance"":""99127"",""sexe"":""M"",""nomUsage"":""DUPONT"",""prenoms"":[""PIERRE"",""PAUL""],""anneeDateDeNaissance"":1984,""moisDateDeNaissance"":12}",200,"{
   ""status"": ""beneficiaire_sans_participation_financiere"",
   ""dateDebut"": ""2023-02-01"",
   ""dateFin"": ""2024-02-01""
@@ -26,17 +26,17 @@ Ce cas permet de tester :
 Ce cas permet de tester :
 - [Param. appel] lieu de naissance en France
 - [Param. appel] sexe masculin
-- [Réponse] statut non-bénéficiaire de la complémentaire santé solidaire","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M"",""nomUsage"":""DUPONT"",""prenoms"":[""PIERRE""],""anneeDateDeNaissance"":1966,""moisDateDeNaissance"":6}",200,"{
+- [Réponse] statut non-bénéficiaire de la complémentaire santé solidaire","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M"",""nomUsage"":""DUPONT"",""prenoms"":[""PIERRE""],""anneeDateDeNaissance"":1966,""moisDateDeNaissance"":6}",200,"{
   ""status"": ""non_beneficiaire_css"",
   ""dateDebut"": ""null"",
   ""dateFin"": ""null""
 }"
-,Dossier non trouvé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00404"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",404,"{
+,Dossier non trouvé,"{""codeInseeLieuDeNaissance"":""00404"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
 }"
-,Timeout - délai d'attente dépassé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
+,Timeout - délai d'attente dépassé,"{""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
   ""error"": ""network_error"",
   ""reason"": ""timeout of 10000 ms exceeded"",
   ""message"": ""Une erreur est survenue lors de l'appel au fournisseur de donnée""

--- a/payloads/api_particulier_v2_cnav_prime_activite/404.yaml
+++ b/payloads/api_particulier_v2_cnav_prime_activite/404.yaml
@@ -2,7 +2,6 @@
 description: |-
   ## Allocataire non trouvé
 params:
-  recipient: '13002526500013'
   nomNaissance: 'DUBOCHE'
   prenoms[]:
   - 'JEROME'

--- a/payloads/api_particulier_v2_cnav_prime_activite/503.yaml
+++ b/payloads/api_particulier_v2_cnav_prime_activite/503.yaml
@@ -1,7 +1,6 @@
 ---
 description: "Timeout - délai d'attente dépassé"
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00503'
   codePaysLieuDeNaissance: '99100'
   sexe: F

--- a/payloads/api_particulier_v2_cnav_prime_activite/README.md
+++ b/payloads/api_particulier_v2_cnav_prime_activite/README.md
@@ -169,7 +169,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "nomNaissance": "DUBOCHE",
     "prenoms[]": [
       "JEROME"
@@ -205,7 +204,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
+    -G -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/prime-activite"
   ```
 
@@ -222,7 +221,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00503",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -251,7 +249,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/prime-activite"
   ```
 

--- a/payloads/api_particulier_v2_cnav_prime_activite/summary.csv
+++ b/payloads/api_particulier_v2_cnav_prime_activite/summary.csv
@@ -17,12 +17,12 @@ Titre,Description,Paramètres,Status,Réponse
   ""dateDebut"": null,
   ""dateFin"": null
 }"
-,## Allocataire non trouvé,"{""recipient"":""13002526500013"",""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
+,## Allocataire non trouvé,"{""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
 }"
-,Timeout - délai d'attente dépassé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
+,Timeout - délai d'attente dépassé,"{""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
   ""error"": ""network_error"",
   ""reason"": ""timeout of 10000 ms exceeded"",
   ""message"": ""Une erreur est survenue lors de l'appel au fournisseur de donnée""

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-couple-2_enfants-qf_msa_150_mai23.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-couple-2_enfants-qf_msa_150_mai23.yaml
@@ -13,7 +13,6 @@ description: |-
   - [Réponse] Quotient familial de 150
   - [Réponse] Quotient familial ancien de mai 2023
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-etranger.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-etranger.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS ETRANGER
 
@@ -7,7 +7,6 @@ description: |-
   et la réponse lorsque celui ci est trouvé.
 
 params:
-  recipient: '13002526500013'
   codePaysLieuDeNaissance: '99350'
   sexe: 'M'
   nomNaissange: 'FAKIR'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-limite-erreur-phonetique.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-limite-erreur-phonetique.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -11,7 +11,6 @@ description: |-
   d'erreur selon les informations que vous fournirez.
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-limite-faute-de-frappe.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-limite-faute-de-frappe.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -11,7 +11,6 @@ description: |-
   d'erreur selon les informations que vous fournirez.
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-nominal-peu-de-donnee-naissance.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-nominal-peu-de-donnee-naissance.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
   
@@ -12,7 +12,6 @@ description: |-
   d'erreur selon les informations que vous fournirez.
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-nominal-peu-de-donnée-prenom.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-nominal-peu-de-donnée-prenom.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -12,7 +12,6 @@ description: |-
   d'erreur selon les informations que vous fournirez.
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-nominal.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-identite-cas-nominal.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -10,7 +10,6 @@ description: |-
   d'erreur selon les informations que vous fournirez.
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-seul-1_enfant-qf_caf_650.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-seul-1_enfant-qf_caf_650.yaml
@@ -8,7 +8,6 @@ description: |-
   - [Réponse] Régime CAF
   - [Réponse] Quotient familial de 650
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-seul-sans_enfant-qf_caf_2550.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/200-seul-sans_enfant-qf_caf_2550.yaml
@@ -9,7 +9,6 @@ description: |-
   - [Réponse] Quotient familial de 2550
   - [Réponse] Quotient familial du mois en cours
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-limite-erreur-phonetique.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-limite-erreur-phonetique.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -11,7 +11,6 @@ description: |-
   d'erreur selon les informations que vous fournirez.
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-limite-faute-de-frappe.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-limite-faute-de-frappe.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -11,7 +11,6 @@ description: |-
   d'erreur selon les informations que vous fournirez.
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-nominal-trop-peu-de-donnee-naissance.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-nominal-trop-peu-de-donnee-naissance.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -6,7 +6,6 @@ description: |-
   Les données concernant la date de naissance ont été retirée
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-nominal-trop-peu-de-donnee-prenom.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/404-identite-cas-nominal-trop-peu-de-donnee-prenom.yaml
@@ -1,4 +1,4 @@
-
+---
 description: |-
   ## IDENTITÉ CAS NOMINAL
 
@@ -6,7 +6,6 @@ description: |-
   Le nom ainsi que les deuxième et troisième prenoms ont été retiré des données
 
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '08480'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/404.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/404.yaml
@@ -1,7 +1,6 @@
 ---
 description: "Dossier non trouvé"
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00404'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/503.yaml
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/503.yaml
@@ -1,7 +1,6 @@
 ---
 description: "Timeout - délai d'attente dépassé"
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00503'
   codePaysLieuDeNaissance: '99100'
   sexe: 'F'

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/README.md
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/README.md
@@ -21,7 +21,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -109,7 +108,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=ROUX' -d 'prenoms[]=JEANNE' -d 'prenoms[]=STEPHANIE' -d 'anneeDateDeNaissance=1987' -d 'moisDateDeNaissance=6' -d 'annee=2023' -d 'mois=5' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=ROUX' -d 'prenoms[]=JEANNE' -d 'prenoms[]=STEPHANIE' -d 'anneeDateDeNaissance=1987' -d 'moisDateDeNaissance=6' -d 'annee=2023' -d 'mois=5' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -130,7 +129,6 @@ et la réponse lorsque celui ci est trouvé.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codePaysLieuDeNaissance": "99350",
     "sexe": "M",
     "nomNaissange": "FAKIR",
@@ -190,7 +188,7 @@ et la réponse lorsque celui ci est trouvé.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codePaysLieuDeNaissance=99350' -d 'sexe=M' -d 'nomNaissange=FAKIR' -d 'prenoms[]=EYMEN' -d 'prenoms[]=MOHAMED' -d 'anneeDateDeNaissance=1992' -d 'moisDateDeNaissance=11' -d 'jourDateDeNaissance=14' \
+    -G -d 'codePaysLieuDeNaissance=99350' -d 'sexe=M' -d 'nomNaissange=FAKIR' -d 'prenoms[]=EYMEN' -d 'prenoms[]=MOHAMED' -d 'anneeDateDeNaissance=1992' -d 'moisDateDeNaissance=11' -d 'jourDateDeNaissance=14' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -215,7 +213,6 @@ d'erreur selon les informations que vous fournirez.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -277,7 +274,7 @@ d'erreur selon les informations que vous fournirez.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXI' -d 'prenoms[]=GEROME' -d 'prenoms[]=JEN-PHILIPE' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXI' -d 'prenoms[]=GEROME' -d 'prenoms[]=JEN-PHILIPE' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -302,7 +299,6 @@ d'erreur selon les informations que vous fournirez.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -364,7 +360,7 @@ d'erreur selon les informations que vous fournirez.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEIXS' -d 'prenoms[]=GR%C3%89%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEIXS' -d 'prenoms[]=GR%C3%89%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -390,7 +386,6 @@ d'erreur selon les informations que vous fournirez.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -450,7 +445,7 @@ d'erreur selon les informations que vous fournirez.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'prenoms[]=G%C3%89R%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'prenoms[]=G%C3%89R%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -476,7 +471,6 @@ d'erreur selon les informations que vous fournirez.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -536,7 +530,7 @@ d'erreur selon les informations que vous fournirez.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -560,7 +554,6 @@ d'erreur selon les informations que vous fournirez.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -622,7 +615,7 @@ d'erreur selon les informations que vous fournirez.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'prenoms[]=G%C3%89R%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'prenoms[]=G%C3%89R%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -645,7 +638,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -712,7 +704,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=BERNARD' -d 'prenoms[]=ELODIE' -d 'anneeDateDeNaissance=1990' -d 'moisDateDeNaissance=3' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=BERNARD' -d 'prenoms[]=ELODIE' -d 'anneeDateDeNaissance=1990' -d 'moisDateDeNaissance=3' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -736,7 +728,6 @@ Ce cas permet de tester :
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -795,7 +786,7 @@ Ce cas permet de tester :
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -820,7 +811,6 @@ d'erreur selon les informations que vous fournirez.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -856,7 +846,7 @@ d'erreur selon les informations que vous fournirez.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXI' -d 'prenoms[]=GEROME' -d 'prenoms[]=JEN-PHILIPE' -d 'anneeDateDeNaissance=1982' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXI' -d 'prenoms[]=GEROME' -d 'prenoms[]=JEN-PHILIPE' -d 'anneeDateDeNaissance=1982' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -881,7 +871,6 @@ d'erreur selon les informations que vous fournirez.
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -917,7 +906,7 @@ d'erreur selon les informations que vous fournirez.
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEIXS' -d 'prenoms[]=GR%C3%89%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEIXS' -d 'prenoms[]=GR%C3%89%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' -d 'anneeDateDeNaissance=1982' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -937,7 +926,6 @@ Les données concernant la date de naissance ont été retirée
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -972,7 +960,7 @@ Les données concernant la date de naissance ont été retirée
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'prenoms[]=G%C3%89R%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'nomUsage=LEFEBVRE' -d 'prenoms[]=ALEXIS' -d 'prenoms[]=G%C3%89R%C3%94ME' -d 'prenoms[]=JEAN-PHILIPPE' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -992,7 +980,6 @@ Le nom ainsi que les deuxième et troisième prenoms ont été retiré des donn�
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "08480",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F",
@@ -1027,7 +1014,7 @@ Le nom ainsi que les deuxième et troisième prenoms ont été retiré des donn�
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'prenoms[]=ALEXIS' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
+    -G -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' -d 'prenoms[]=ALEXIS' -d 'anneeDateDeNaissance=1982' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=27' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -1044,7 +1031,6 @@ Le nom ainsi que les deuxième et troisième prenoms ont été retiré des donn�
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00404",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -1073,7 +1059,7 @@ Le nom ainsi que les deuxième et troisième prenoms ont été retiré des donn�
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00404' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00404' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 
@@ -1090,7 +1076,6 @@ Le nom ainsi que les deuxième et troisième prenoms ont été retiré des donn�
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00503",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -1119,7 +1104,7 @@ Le nom ainsi que les deuxième et troisième prenoms ont été retiré des donn�
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/composition-familiale-v2"
   ```
 

--- a/payloads/api_particulier_v2_cnav_quotient_familial_v2/summary.csv
+++ b/payloads/api_particulier_v2_cnav_quotient_familial_v2/summary.csv
@@ -10,7 +10,7 @@ Ce cas permet de tester :
 - [Réponse] Tableau d'informations car deux enfants
 - [Réponse] Régime MSA
 - [Réponse] Quotient familial de 150
-- [Réponse] Quotient familial ancien de mai 2023","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""ROUX"",""prenoms"":[""JEANNE"",""STEPHANIE""],""anneeDateDeNaissance"":1987,""moisDateDeNaissance"":6,""annee"":2023,""mois"":5}",200,"{
+- [Réponse] Quotient familial ancien de mai 2023","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""ROUX"",""prenoms"":[""JEANNE"",""STEPHANIE""],""anneeDateDeNaissance"":1987,""moisDateDeNaissance"":6,""annee"":2023,""mois"":5}",200,"{
   ""regime"": ""MSA"",
   ""allocataires"": [
     {
@@ -69,7 +69,7 @@ Ce cas permet de tester :
 
 Ce cas est le cas personne étrangère de l'ensemble des cas de test d'identité/limite.
 Il a pour but de décrire une personne fictive avec l'ensemble de ses paramètres
-et la réponse lorsque celui ci est trouvé.","{""recipient"":""13002526500013"",""codePaysLieuDeNaissance"":""99350"",""sexe"":""M"",""nomNaissange"":""FAKIR"",""prenoms"":[""EYMEN"",""MOHAMED""],""anneeDateDeNaissance"":1992,""moisDateDeNaissance"":11,""jourDateDeNaissance"":14}",200,"{
+et la réponse lorsque celui ci est trouvé.","{""codePaysLieuDeNaissance"":""99350"",""sexe"":""M"",""nomNaissange"":""FAKIR"",""prenoms"":[""EYMEN"",""MOHAMED""],""anneeDateDeNaissance"":1992,""moisDateDeNaissance"":11,""jourDateDeNaissance"":14}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -104,7 +104,7 @@ Il comporte des erreurs dans les prenoms qui ne changent pas la phonétique. Ici
 de donnée de naissance pour compenser les erreurs et retrouver l'identité.
 
 Vous trouverez des variations des paramètres d'entré ainsi que les différents cas
-d'erreur selon les informations que vous fournirez.","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXI"",""GEROME"",""JEN-PHILIPE""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
+d'erreur selon les informations que vous fournirez.","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXI"",""GEROME"",""JEN-PHILIPE""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -139,7 +139,7 @@ Il comporte des erreurs dans les prenoms qui changent la phonétique. Ici, il y 
 de donnée de naissance pour compenser les erreurs et retrouver l'identité.
 
 Vous trouverez des variations des paramètres d'entré ainsi que les différents cas
-d'erreur selon les informations que vous fournirez.","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEIXS"",""GRÉÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
+d'erreur selon les informations que vous fournirez.","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEIXS"",""GRÉÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -175,7 +175,7 @@ Il y a suffisament de données de nom/prénoms dans les paramètres pour compens
 l'absence des données de naissance.
 
 Vous trouverez des variations des paramètres d'entré ainsi que les différents cas
-d'erreur selon les informations que vous fournirez.","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS"",""GÉRÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982}",200,"{
+d'erreur selon les informations que vous fournirez.","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS"",""GÉRÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -211,7 +211,7 @@ Il y suffisament de donnée de naissance dans cet ensemble de paramètre pour pe
 de compenser les données manquantes
 
 Vous trouverez des variations des paramètres d'entré ainsi que les différents cas
-d'erreur selon les informations que vous fournirez.","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
+d'erreur selon les informations que vous fournirez.","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -245,7 +245,7 @@ Il a pour but de décrire une personne fictive avec l'ensemble de ses paramètre
 et la réponse lorsque celui ci est trouvé.
 
 Vous trouverez des variations des paramètres d'entré ainsi que les différents cas
-d'erreur selon les informations que vous fournirez.","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS"",""GÉRÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
+d'erreur selon les informations que vous fournirez.","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS"",""GÉRÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -278,7 +278,7 @@ Ce cas permet de tester :
 - [Param. appel] Lieu de naissance en France
 - [Param. appel] Sexe feminin
 - [Réponse] Régime CAF
-- [Réponse] Quotient familial de 650","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""BERNARD"",""prenoms"":[""ELODIE""],""anneeDateDeNaissance"":1990,""moisDateDeNaissance"":3}",200,"{
+- [Réponse] Quotient familial de 650","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""BERNARD"",""prenoms"":[""ELODIE""],""anneeDateDeNaissance"":1990,""moisDateDeNaissance"":3}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -322,7 +322,7 @@ Ce cas permet de tester :
 - [Param. appel] sexe masculin
 - [Réponse] Régime CAF
 - [Réponse] Quotient familial de 2550
-- [Réponse] Quotient familial du mois en cours","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12}",200,"{
+- [Réponse] Quotient familial du mois en cours","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12}",200,"{
   ""regime"": ""CNAF"",
   ""allocataires"": [
     {
@@ -357,7 +357,7 @@ Il comporte des erreurs dans les prenoms qui changent ne change pas ou peu la ph
 de donnée de naissance pour compenser les erreurs et retrouver l'identité.
 
 Vous trouverez des variations des paramètres d'entré ainsi que les différents cas
-d'erreur selon les informations que vous fournirez.","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXI"",""GEROME"",""JEN-PHILIPE""],""anneeDateDeNaissance"":1982}",404,"{
+d'erreur selon les informations que vous fournirez.","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXI"",""GEROME"",""JEN-PHILIPE""],""anneeDateDeNaissance"":1982}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
@@ -370,7 +370,7 @@ Il comporte des erreurs dans les prenoms qui changent la phonétique. Ici, il n'
 de donnée de naissance pour compenser les erreurs et retrouver l'identité.
 
 Vous trouverez des variations des paramètres d'entré ainsi que les différents cas
-d'erreur selon les informations que vous fournirez.","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEIXS"",""GRÉÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982}",404,"{
+d'erreur selon les informations que vous fournirez.","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEIXS"",""GRÉÔME"",""JEAN-PHILIPPE""],""anneeDateDeNaissance"":1982}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
@@ -378,7 +378,7 @@ d'erreur selon les informations que vous fournirez.","{""recipient"":""130025265
 ,"## IDENTITÉ CAS NOMINAL
 
 Ce cas fait partie de l'ensemble des cas de test identite-cas-nominal/limite.
-Les données concernant la date de naissance ont été retirée","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS"",""GÉRÔME"",""JEAN-PHILIPPE""]}",404,"{
+Les données concernant la date de naissance ont été retirée","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""nomUsage"":""LEFEBVRE"",""prenoms"":[""ALEXIS"",""GÉRÔME"",""JEAN-PHILIPPE""]}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
@@ -386,17 +386,17 @@ Les données concernant la date de naissance ont été retirée","{""recipient""
 ,"## IDENTITÉ CAS NOMINAL
 
 Ce cas fait partie de l'ensemble des cas de test identite-cas-nominal/limite.
-Le nom ainsi que les deuxième et troisième prenoms ont été retiré des données","{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""prenoms"":[""ALEXIS""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",404,"{
+Le nom ainsi que les deuxième et troisième prenoms ont été retiré des données","{""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F"",""prenoms"":[""ALEXIS""],""anneeDateDeNaissance"":1982,""moisDateDeNaissance"":12,""jourDateDeNaissance"":27}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
 }"
-,Dossier non trouvé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00404"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",404,"{
+,Dossier non trouvé,"{""codeInseeLieuDeNaissance"":""00404"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
 }"
-,Timeout - délai d'attente dépassé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
+,Timeout - délai d'attente dépassé,"{""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
   ""error"": ""network_error"",
   ""reason"": ""timeout of 10000 ms exceeded"",
   ""message"": ""Une erreur est survenue lors de l'appel au fournisseur de donnée""

--- a/payloads/api_particulier_v2_cnav_revenu_solidarite_active/404.yaml
+++ b/payloads/api_particulier_v2_cnav_revenu_solidarite_active/404.yaml
@@ -2,7 +2,6 @@
 description: |-
   ## Allocataire non trouvé
 params:
-  recipient: '13002526500013'
   nomNaissance: 'DUBOCHE'
   prenoms[]:
   - 'JEROME'

--- a/payloads/api_particulier_v2_cnav_revenu_solidarite_active/503.yaml
+++ b/payloads/api_particulier_v2_cnav_revenu_solidarite_active/503.yaml
@@ -1,7 +1,6 @@
 ---
 description: "Timeout - délai d'attente dépassé"
 params:
-  recipient: '13002526500013'
   codeInseeLieuDeNaissance: '00503'
   codePaysLieuDeNaissance: '99100'
   sexe: F

--- a/payloads/api_particulier_v2_cnav_revenu_solidarite_active/README.md
+++ b/payloads/api_particulier_v2_cnav_revenu_solidarite_active/README.md
@@ -169,7 +169,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "nomNaissance": "DUBOCHE",
     "prenoms[]": [
       "JEROME"
@@ -205,7 +204,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
+    -G -d 'nomNaissance=DUBOCHE' -d 'prenoms[][]=JEROME' -d 'anneeDateDeNaissance=2002' -d 'moisDateDeNaissance=12' -d 'jourDateDeNaissance=5' -d 'codeInseeLieuDeNaissance=08480' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=M' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/revenu-solidarite-active"
   ```
 
@@ -222,7 +221,6 @@
 
   ```json
   {
-    "recipient": "13002526500013",
     "codeInseeLieuDeNaissance": "00503",
     "codePaysLieuDeNaissance": "99100",
     "sexe": "F"
@@ -251,7 +249,7 @@
 
   ```bash
   curl -H "X-Api-Key: $token" \
-    -G -d 'recipient=13002526500013' -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
+    -G -d 'codeInseeLieuDeNaissance=00503' -d 'codePaysLieuDeNaissance=99100' -d 'sexe=F' \
     --url "https://staging.particulier.api.gouv.fr/api/v2/revenu-solidarite-active"
   ```
 

--- a/payloads/api_particulier_v2_cnav_revenu_solidarite_active/summary.csv
+++ b/payloads/api_particulier_v2_cnav_revenu_solidarite_active/summary.csv
@@ -17,12 +17,12 @@ Titre,Description,Paramètres,Status,Réponse
   ""dateDebut"": null,
   ""dateFin"": null
 }"
-,## Allocataire non trouvé,"{""recipient"":""13002526500013"",""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
+,## Allocataire non trouvé,"{""nomNaissance"":""DUBOCHE"",""prenoms[]"":[""JEROME""],""anneeDateDeNaissance"":2002,""moisDateDeNaissance"":12,""jourDateDeNaissance"":5,""codeInseeLieuDeNaissance"":""08480"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""M""}",404,"{
   ""error"": ""not_found"",
   ""reason"": ""Dossier allocataire inexistant. Le document ne peut être édité."",
   ""message"": ""Dossier allocataire inexistant. Le document ne peut être édité.""
 }"
-,Timeout - délai d'attente dépassé,"{""recipient"":""13002526500013"",""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
+,Timeout - délai d'attente dépassé,"{""codeInseeLieuDeNaissance"":""00503"",""codePaysLieuDeNaissance"":""99100"",""sexe"":""F""}",503,"{
   ""error"": ""network_error"",
   ""reason"": ""timeout of 10000 ms exceeded"",
   ""message"": ""Une erreur est survenue lors de l'appel au fournisseur de donnée""


### PR DESCRIPTION
Recipient is a mandatory params when making an FC call on all the cnav API.

Recipient is not required (and useless) when making call on CNAV api with identity params